### PR TITLE
Get ComponentsByStructure to work properly

### DIFF
--- a/app/graphql/binda/api/fields/components_by_structure_field.rb
+++ b/app/graphql/binda/api/fields/components_by_structure_field.rb
@@ -2,9 +2,9 @@ Binda::Api::Fields::ComponentsByStructureField = GraphQL::Field.define do
   name 'componentsByStructure'
   type Binda::Api::Types::ComponentType.connection_type
 
-  argument :slug, !types.String
+  argument :slug, types.String
   argument :structure_slug, !types.String
-  argument :publish_state, !types.String
+  argument :publish_state, types.String
 
   resolve(Binda::Api::Resolvers::ComponentsByStructureResolver.new)
 end

--- a/app/graphql/binda/api/resolvers/components_by_structure_resolver.rb
+++ b/app/graphql/binda/api/resolvers/components_by_structure_resolver.rb
@@ -1,6 +1,11 @@
 class Binda::Api::Resolvers::ComponentsByStructureResolver
   def call(obj, args, ctx = {})
+    user = ctx[:current_user]
+    query_params = args.to_h.symbolize_keys
+    query_params.reject!{|k,v| [:first, :last, :after, :before].include? k }
+    structure_slug = query_params.delete(:structure_slug)
     structure_ids = user.structures.where(slug: structure_slug).pluck(:id)
+
     Binda::Component.where( structure_id: structure_ids )
                     .order('binda_components.position ASC')
   end

--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -91,6 +91,25 @@ describe "GraphQL API" do
     expect(json['data']['components']['edges'].size).to eq(0)
   end
 
+  it 'returns components by structure' do
+    data = '{
+      components_by_structure(structure_slug: "1-structure"){
+        edges{
+          node{
+            id
+            name
+            slug
+          }
+        }
+      }
+    }'    
+    post graphql_path(query: data, api_key: @authorized_user.api_key)
+    expect(response).to be_success
+    expect(json['data']).to have_key 'components_by_structure'
+    expect(json['data']['components_by_structure']['edges']).to be_kind_of(Array)
+    expect(json['data']['components_by_structure']['edges'][0]['node']).to have_key 'name'
+  end
+
   it "returns a board by its slug" do
     @authorized_user.structures << Binda::Board.find_by(slug: 'dashboard').structure
     


### PR DESCRIPTION
fixes #18 - gets ComponentsByStructure to work properly

NOTE: This also changes the argument requirements to not force `slug` and `publish_state` as that seems like it should be the desired behavior